### PR TITLE
InAppBrowserNotify example

### DIFF
--- a/react-web-app/src/App.js
+++ b/react-web-app/src/App.js
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import PayCard from './PayCard';
 
 const ACCESS_ID = process.env.REACT_APP_TRUSTLY_ACCESS_ID;
@@ -13,6 +14,20 @@ function App() {
     widgetContainerId: "widget"
   };
 
+  useEffect(() => {
+    window.Trustly.addPanelListener((command, obj) => {
+      switch(command) {
+        case "message":
+          if (obj.type === "PayWithMyBank.OpenExternalBrowser") {
+            //open inAppBrowser
+            window.webkit.messageHandlers.appInterface.postMessage({ url: obj.url });
+          }
+          break;
+        default:;
+      }
+    })
+  }, [])
+
   const returnEstablishData = () => {
     let lightboxRedirectURL = serverURL ? serverURL : "#";
     let data = {
@@ -24,8 +39,15 @@ function App() {
       paymentType: 'Retrieval',
       returnUrl: `${lightboxRedirectURL}/return`,
       cancelUrl: `${lightboxRedirectURL}/cancel`,
-      metadata: {}  
+      customer: {
+        name: 'John smith',
+        address: {
+          country: 'US'
+        },
+      },
+      metadata: {}
     };
+
     // check query params for mobile
     if (params.get("integrationContext") && params.get("urlScheme")) {
 			if (!data.metadata) data.metadata = {};

--- a/react-web-app/src/index.js
+++ b/react-web-app/src/index.js
@@ -6,9 +6,7 @@ import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  <App />
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
This draft PR is meant to demonstrate an alternative method for handling OAuth login flows using the `InAppBrowserNotify` option for the `metadata.integrationContext` property of the Trustly SDK's [Establish Data](https://amer.developers.trustly.com/payments/docs/establish-data#metadata-object) parameter.

In this example, rather than listening for the `window.open` event in the native application, the Trustly SDK's [addPanelListener](https://amer.developers.trustly.com/payments/docs/sdk-callback-events) function is utilized to manually send a message from the web page to the native application.

In this example, the [WebKit MessageHandler](https://developer.apple.com/documentation/webkit/wkscriptmessagehandler) interface is used to post a message to the iOS app. See the [react-app/src/App.js](https://github.com/TrustlyInc/trustly-webview-example/blob/081060b4eb141c238231eac2f8d649d277d42f9a/react-web-app/src/App.js#L18) file for more details. However, any method appropriate to communicate with your native applications from this panel listener callback function can be used. 

Finally, your native application will need to receive the message and carry on with the secure authentication session implementation. In this example the WKScriptMessageHandler class is used to detect the message and build the ASWebAuthenticationSession. See the [ViewController](https://github.com/TrustlyInc/trustly-webview-example/blob/081060b4eb141c238231eac2f8d649d277d42f9a/ios-app/in-app-browser-ios/ViewController.swift#LL57C1-L57C1) file for more details.

> Note: the Android app in this example repository has not been modified to integrate with this variation. If you require assistance with Android implementation, please open an issue in this repository or reach out to your Trustly support team member.